### PR TITLE
retrieve "UpdatedAt" field from scrutiny api 

### DIFF
--- a/custom_components/scrutiny/const.py
+++ b/custom_components/scrutiny/const.py
@@ -13,7 +13,7 @@ DOMAIN: str = "scrutiny"
 # User-visible name of the integration. Also used as default manufacturer for devices.
 NAME: str = "Scrutiny"
 # Version of the integration.
-VERSION: str = "0.3.3"
+VERSION: str = "0.3.4"
 
 # Configuration keys used in config_flow.py and __init__.py.
 CONF_HOST: str = "host"  # Key for the Scrutiny server host.
@@ -58,6 +58,7 @@ ATTR_MODEL_NAME: str = "model_name"  # e.g., "Samsung SSD 860 EVO"
 ATTR_FIRMWARE: str = "firmware"  # Firmware version of the disk.
 ATTR_CAPACITY: str = "capacity"  # Disk capacity in bytes.
 ATTR_SERIAL_NUMBER: str = "serial_number"  # Serial number of the disk.
+ATTR_UPDATED_AT: str = "UpdatedAt" # Last update timestamp of the disk.
 
 # Keys specifically from the '/api/summary' -> 'device' object of a disk.
 ATTR_SUMMARY_DEVICE_STATUS: str = (

--- a/custom_components/scrutiny/manifest.json
+++ b/custom_components/scrutiny/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "aiohttp>=3.9.0"
   ],
-  "version": "0.3.3"
+  "version": "0.3.4"
 }

--- a/custom_components/scrutiny/sensor.py
+++ b/custom_components/scrutiny/sensor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.sensor import (
@@ -52,6 +53,7 @@ from .const import (
     ATTR_THRESH,
     ATTR_WHEN_FAILED,
     ATTR_WORST,
+    ATTR_UPDATED_AT,
     DOMAIN,  # The integration's domain
     KEY_DETAILS_METADATA,  # Key for SMART attribute metadata in coordinator data
     KEY_DETAILS_SMART_LATEST,  # Key for latest SMART details in coordinator data
@@ -136,6 +138,13 @@ MAIN_DISK_SENSOR_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = (
         icon="mdi:shield-check-outline",
         device_class=SensorDeviceClass.ENUM,
         options=[*ATTR_SMART_STATUS_MAP.values(), ATTR_SMART_STATUS_UNKNOWN],
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SensorEntityDescription(
+        key=ATTR_UPDATED_AT,
+        name="Last Update",
+        icon="mdi:update",
+        device_class=SensorDeviceClass.TIMESTAMP,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
 )
@@ -382,6 +391,21 @@ class ScrutinyMainDiskSensor(
                 if status_code is not None
                 else ATTR_SMART_STATUS_UNKNOWN
             )
+        elif key == ATTR_UPDATED_AT:
+            updated_at_str = summary_device_data.get(ATTR_UPDATED_AT)
+            if updated_at_str and isinstance(updated_at_str, str):
+                try:
+                    # The timestamp ends with 'Z', which fromisoformat doesn't like.
+                    # Replace 'Z' with '+00:00' for UTC timezone.
+                    if updated_at_str.endswith("Z"):
+                        updated_at_str = updated_at_str[:-1] + "+00:00"
+                    value = datetime.fromisoformat(updated_at_str)
+                except ValueError:
+                    LOGGER.warning(
+                        "Could not parse timestamp: %s", updated_at_str
+                    )
+                    value = None
+
         # Set the sensor's native value.
         self._attr_native_value = value
 


### PR DESCRIPTION
for disk status to not rely on HA's internal field update datetime, but rather the real update timestamp for the hardware (to know if we are looking at some expired data)