### PR TITLE
Batch device detail requests to prevent API overload

### DIFF
--- a/custom_components/scrutiny/api.py
+++ b/custom_components/scrutiny/api.py
@@ -145,7 +145,8 @@ class ScrutinyApiClient:
 
         try:
             # Set a timeout for the request.
-            async with asyncio.timeout(10):
+            # Increased to 30s to handle large numbers of disks
+            async with asyncio.timeout(30):
                 response = await self._session.request(
                     method,
                     url,

--- a/custom_components/scrutiny/coordinator.py
+++ b/custom_components/scrutiny/coordinator.py
@@ -297,16 +297,31 @@ class ScrutinyDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
                 # Create a task to fetch details for this WWN.
                 detail_tasks.append(self.api_client.async_get_device_details(wwn))
 
-            # 2. Fetch detailed data for all disks concurrently.
+            # 2. Fetch detailed data for all disks in batches to avoid overwhelming Scrutiny.
             if detail_tasks:
                 self.logger.debug("Fetching details for %d disk(s).", len(detail_tasks))
-                # `asyncio.gather` runs all detail_tasks concurrently.
-                # `return_exceptions=True` means if a task raises an exception,
-                # the exception object is returned in its place in the results list,
-                # rather than stopping all other tasks.
-                detail_results = await asyncio.gather(
-                    *detail_tasks, return_exceptions=True
-                )
+                # Batch size: process 5 disks at a time to avoid overwhelming the API
+                batch_size = 5
+                detail_results = []
+                
+                for i in range(0, len(detail_tasks), batch_size):
+                    batch = detail_tasks[i:i + batch_size]
+                    self.logger.debug(
+                        "Fetching batch %d-%d of %d disks",
+                        i + 1,
+                        min(i + batch_size, len(detail_tasks)),
+                        len(detail_tasks),
+                    )
+                    # `asyncio.gather` runs this batch concurrently.
+                    # `return_exceptions=True` means if a task raises an exception,
+                    # the exception object is returned in its place in the results list,
+                    # rather than stopping all other tasks.
+                    batch_results = await asyncio.gather(*batch, return_exceptions=True)
+                    detail_results.extend(batch_results)
+                    # Small delay between batches to give Scrutiny time to breathe
+                    if i + batch_size < len(detail_tasks):
+                        await asyncio.sleep(0.5)
+                
                 # Process the results (or exceptions) for each disk.
                 for i, wwn_key in enumerate(wwn_order):
                     self._process_detail_results(


### PR DESCRIPTION
### Problem
When monitoring many disks (30+), the integration fetches device details for all disks simultaneously. This creates a burst of concurrent API requests that can:
- Overwhelm the Scrutiny container (CPU spike)
- Cause timeout errors
- Result in sensors showing "Unknown" status due to failed detail fetches

While this is not a problem across all deployments. When running scrutiny in a container with resource limits this causes it to max out limits in a normally unrealistic way IMO. The webUI for instance doesn't get anywhere close to the amount that the integration does. 

### Solution
1. **Batch detail requests**: Process disks in batches of 5 instead of all at once
2. **Add delay between batches**: 0.5 second pause between batches to let Scrutiny process requests
3. **Increase timeout**: Raised API timeout from 10s to 30s to accommodate slower responses under load

### Impact
- Dramatically reduces load on Scrutiny container
- Eliminates timeout errors when monitoring many disks
- Slightly increases total update time (e.g., 30 disks: ~3 seconds of delay vs instant)
- No functional changes - just spreads the load over time

### Testing
Tested with 30+ disks - no more timeouts, Scrutiny stays at a more normal resource consumption.