### PR TITLE
v1.1.1 cumulative resync from raetha fork with repo updates

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-# These are supported funding model platforms
-
-github: raetha

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         id: changelog
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          NOTES=$(awk "/^## $VERSION/{found=1; next} found && /^## /{exit} found{print}" CHANGELOG.md)
+          NOTES=$(awk "/^## \[?$VERSION\]?/{found=1; next} found && /^## /{exit} found{print}" CHANGELOG.md)
           if [ -z "$NOTES" ]; then
             NOTES="See CHANGELOG.md for details."
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [1.1.1] — 2026-04-30
+
+### Repository
+
+- Transferred to [vitals5/ha_scrutiny](https://github.com/vitals5/ha_scrutiny) as the
+  primary upstream repository.
+- `manifest.json` — `codeowners` updated to `["@vitals5", "@raetha"]`; `documentation`
+  and `issue_tracker` URLs updated to the upstream repository.
+- `LICENSE` — added `Copyright (c) 2024 vitals5` to correctly reflect the original
+  author alongside the fork author.
+- `README.md` — HACS badge updated from "Custom" to "Default" (the integration is in
+  the default HACS catalog); install instructions simplified accordingly; banner image
+  restored; attribution and all repository URLs updated to upstream.
+- `CONTRIBUTING.md` — repository URL updated to upstream.
+- `CHANGELOG.md` — compare links updated to upstream repository.
+- `.github/FUNDING.yml` — removed (personal funding link, not appropriate in a shared
+  upstream repository).
+
 ## [1.1.0] — 2026-04-30
 
 ### Scrutiny 0.9.0 compatibility
@@ -140,6 +158,7 @@ HA core team).
 
 ---
 
+[1.1.1]: https://github.com/vitals5/ha_scrutiny/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/vitals5/ha_scrutiny/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/vitals5/ha_scrutiny/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/vitals5/ha_scrutiny/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,7 @@ Historical entity data will be reset, but no manual cleanup is required.
 
 ## [1.0.0] — 2026-04-15
 
-Initial public release as a fork of [vitals5/ha_scrutiny](https://github.com/vitals5/ha_scrutiny).
+Initial public release. Originally developed as a fork of [vitals5/ha_scrutiny](https://github.com/vitals5/ha_scrutiny), this is now the primary upstream repository.
 
 This release is a substantial rewrite addressing every open issue and pending PR on the
 upstream repository at the time of the fork, plus a full Home Assistant quality scale
@@ -140,6 +140,6 @@ HA core team).
 
 ---
 
-[1.1.0]: https://github.com/raetha/ha-scrutiny/compare/v1.0.1...v1.1.0
-[1.0.1]: https://github.com/raetha/ha-scrutiny/compare/v1.0.0...v1.0.1
-[1.0.0]: https://github.com/raetha/ha-scrutiny/releases/tag/v1.0.0
+[1.1.0]: https://github.com/vitals5/ha_scrutiny/compare/v1.0.1...v1.1.0
+[1.0.1]: https://github.com/vitals5/ha_scrutiny/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/vitals5/ha_scrutiny/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.1.0 — 2026-04-30
+## [1.1.0] — 2026-04-30
 
 ### Scrutiny 0.9.0 compatibility
 
@@ -70,7 +70,7 @@ Historical entity data will be reset, but no manual cleanup is required.
 - **CI** — matrix testing removed (Python 3.14 only); `ruff format --check` added to
   lint job.
 
-## 1.0.1 — 2026-04-18
+## [1.0.1] — 2026-04-18
 
 ### Bug fixes
 
@@ -91,7 +91,7 @@ Historical entity data will be reset, but no manual cleanup is required.
 - **GitHub Actions deprecation warnings** — updated `actions/checkout` v4 → v6 and
   `actions/setup-python` v5 → v6 (both now run on Node.js 24).
 
-## 1.0.0 — 2026-04-15
+## [1.0.0] — 2026-04-15
 
 Initial public release as a fork of [vitals5/ha_scrutiny](https://github.com/vitals5/ha_scrutiny).
 
@@ -137,3 +137,9 @@ compliance pass.
 All Bronze, Silver, Gold, and Platinum rules satisfied. `quality_scale` set to `gold`
 in `manifest.json` (the maximum accepted value; Platinum is assessed separately by the
 HA core team).
+
+---
+
+[1.1.0]: https://github.com/raetha/ha-scrutiny/compare/v1.0.1...v1.1.0
+[1.0.1]: https://github.com/raetha/ha-scrutiny/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/raetha/ha-scrutiny/releases/tag/v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Contributions are welcome via pull requests at [github.com/raetha/ha-scrutiny](https://github.com/raetha/ha-scrutiny).
+Contributions are welcome via pull requests at [vitals5/ha_scrutiny](https://github.com/vitals5/ha_scrutiny).
 
 ## Development setup
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 MIT License
 
+Copyright (c) 2024 vitals5
 Copyright (c) 2025-2026 raetha
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-[![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/hacs/integration)
-[![GitHub release](https://img.shields.io/github/v/release/raetha/ha-scrutiny?style=plastic)](https://github.com/raetha/ha-scrutiny/releases)
+[![hacs_badge](https://img.shields.io/badge/HACS-Default-teal.svg)](https://github.com/hacs/integration)
+[![GitHub release](https://img.shields.io/github/v/release/vitals5/ha_scrutiny?style=plastic)](https://github.com/vitals5/ha_scrutiny/releases)
+
+![Scrutiny Banner](brands/ha_scrutiny_banner.png)
 
 # Scrutiny — Home Assistant Integration
 
@@ -24,17 +26,17 @@ In addition, sensor entities for individual SMART attributes can be enabled thro
 
 ### Device identity
 
-Devices are named after their **model and serial number** (e.g. `WD Red Plus 4TB (WD40EFZX-12345)`) so you can cross-reference them against TrueNAS, ZFS, or any other tool that identifies disks by serial number. The underlying unique identifier used by Home Assistant is the **WWN** (World Wide Name), which is the IEEE-assigned globally unique identifier that remains stable across reboots and drive path changes. Each disk device includes a **Visit** link that opens its page directly in the Scrutiny UI.
+Devices are named after their **model and serial number** (e.g. `WD Red Plus 4TB (WD40EFZX-12345)`) so you can cross-reference them against TrueNAS, ZFS, or any other tool that identifies disks by serial number. The underlying unique identifier used by Home Assistant is the **Scrutiny disk ID** — a UUIDv5 on Scrutiny ≥ 0.9.0, or the WWN hex string on older releases. Either way it remains stable across reboots and drive path changes. Each disk device includes a **Visit** link that opens its page directly in the Scrutiny UI.
 
 ### Device path (current `/dev/sdX`)
 
-The current device path (e.g. `/dev/sda`) is exposed as the `device_name` attribute on every sensor entity for that disk. You can see it in the entity's attribute panel in the Home Assistant UI. Because Linux device paths are not guaranteed to be stable across reboots, the path shown may not always reflect the current system state — it reflects whatever path Scrutiny last reported. The drive's stable identity in Home Assistant is always the WWN.
+The current device path (e.g. `/dev/sda`) is exposed as the `device_name` attribute on every sensor entity for that disk. You can see it in the entity's attribute panel in the Home Assistant UI. Because Linux device paths are not guaranteed to be stable across reboots, the path shown may not always reflect the current system state — it reflects whatever path Scrutiny last reported. The drive's stable identity in Home Assistant is always the Scrutiny disk ID.
 
 ---
 
 ## Requirements
 
-- Home Assistant 2025.12 or newer
+- Home Assistant 2026.3 or newer
 - A reachable [Scrutiny](https://github.com/AnalogJ/scrutiny) instance (self-hosted, Docker, or TrueNAS App)
 - Network access from Home Assistant to the Scrutiny web interface
 
@@ -44,19 +46,16 @@ The current device path (e.g. `/dev/sda`) is exposed as the `device_name` attrib
 
 ### HACS (Recommended)
 
-This integration is not yet in the default HACS catalog. You can add it as a custom repository:
+This integration is available in the default HACS catalog.
 
 1. Open HACS in Home Assistant
 2. Go to **Integrations**
-3. Click the **⋮** menu → **Custom repositories**
-4. Enter the repository URL: `https://github.com/raetha/ha-scrutiny`
-5. Set category to **Integration** and click **Add**
-6. Find **Scrutiny** in the integration list and install it
-7. Restart Home Assistant
+3. Search for **Scrutiny** and install it
+4. Restart Home Assistant
 
-Or click the button below to add the repository directly:
+Or click the button below to install directly:
 
-[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=raetha&repository=ha-scrutiny&category=integration)
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=vitals5&repository=ha_scrutiny&category=integration)
 
 ### Manual
 
@@ -186,7 +185,7 @@ entities:
 Home Assistant polls the Scrutiny API on the configured scan interval. On each poll:
 
 1. The `/api/summary` endpoint is called to get current status and basic metrics for all disks.
-2. The `/api/device/{wwn}/details` endpoint is called **concurrently** for every disk to retrieve the latest SMART snapshot and attribute metadata.
+2. The `/api/device/{disk_id}/details` endpoint is called **concurrently** for every disk to retrieve the latest SMART snapshot and attribute metadata.
 
 If the Scrutiny server is temporarily unreachable, sensors are marked unavailable and Home Assistant logs a single warning. Polling resumes automatically at the next interval — no restart is required.
 
@@ -236,7 +235,7 @@ All devices and entities created by the integration will be removed automaticall
 
 ## Attribution
 
-This integration was forked from [vitals5/ha_scrutiny](https://github.com/vitals5/ha_scrutiny) by vitals5, and subsequently developed by **[@raetha](https://github.com/raetha)** with design assistance and code generation by **[Claude](https://claude.ai)** (Anthropic).
+Originally created by **[@vitals5](https://github.com/vitals5)**. Substantially developed and maintained by **[@raetha](https://github.com/raetha)**, with design assistance and code generation by **[Claude](https://claude.ai)** (Anthropic).
 
 For the Scrutiny application itself (collector, web server, API), see [AnalogJ/scrutiny](https://github.com/AnalogJ/scrutiny).
 
@@ -244,7 +243,7 @@ For the Scrutiny application itself (collector, web server, API), see [AnalogJ/s
 
 ## Contributing
 
-Issues and pull requests are welcome at [github.com/raetha/ha-scrutiny](https://github.com/raetha/ha-scrutiny).
+Issues and pull requests are welcome at [vitals5/ha_scrutiny](https://github.com/vitals5/ha_scrutiny).
 
 ---
 

--- a/custom_components/scrutiny/const.py
+++ b/custom_components/scrutiny/const.py
@@ -10,7 +10,7 @@ DOMAIN: str = "scrutiny"
 # User-visible name of the integration. Also used as default manufacturer for devices.
 NAME: str = "Scrutiny"
 # Version of the integration.
-VERSION: str = "1.1.0"
+VERSION: str = "1.1.1"
 
 # Configuration keys used in config_flow.py and __init__.py.
 CONF_URL: str = "url"  # Full base URL of the Scrutiny server, e.g. http://host:8080

--- a/custom_components/scrutiny/manifest.json
+++ b/custom_components/scrutiny/manifest.json
@@ -2,13 +2,14 @@
   "domain": "scrutiny",
   "name": "Scrutiny",
   "codeowners": [
+    "@vitals5",
     "@raetha"
   ],
   "config_flow": true,
-  "documentation": "https://github.com/raetha/ha-scrutiny",
+  "documentation": "https://github.com/vitals5/ha_scrutiny",
   "integration_type": "hub",
   "iot_class": "local_polling",
-  "issue_tracker": "https://github.com/raetha/ha-scrutiny/issues",
+  "issue_tracker": "https://github.com/vitals5/ha_scrutiny/issues",
   "loggers": [
     "custom_components.scrutiny"
   ],

--- a/custom_components/scrutiny/manifest.json
+++ b/custom_components/scrutiny/manifest.json
@@ -17,5 +17,5 @@
   "requirements": [
     "aiohttp>=3.11.0"
   ],
-  "version": "1.1.0"
+  "version": "1.1.1"
 }


### PR DESCRIPTION
This is a cumulative rollup that includes all changes made in versions 1.0.0 through 1.1.0 in Raetha's fork at https://github.com/raetha/ha-scrutiny along with correct repo and attribution references. Ultimately you may want to create a combined release note from the CHANGELOG when you release v1.1.1 which should be the next version, though feel free to change if you'd like to start somewhere different.

This PR will resolve issues #9, #38, #39 and #44. It should also accomplish PRs #14, #22, #33, and #37.